### PR TITLE
Replace method GetChannel() due to deprecation

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -139,7 +139,8 @@ func readBotInfo(api *slack.Client) {
 }
 
 func readChannelData(api *slack.Client) {
-	channels, err := api.GetChannels(true)
+	params := slack.GetConversationsParameters{}
+	channels, _, err := api.GetConversations(&params)
 	if err != nil {
 		fmt.Printf("Error getting Channels: %s\n", err)
 		return


### PR DESCRIPTION
https://github.com/slack-go/slack/blob/15ab43e0e495776bd4d7477a99797e41237c4743/channels.go#L341
https://api.slack.com/methods/channels.list